### PR TITLE
Decouple any premise about timezones

### DIFF
--- a/lib/wire_client.rb
+++ b/lib/wire_client.rb
@@ -33,4 +33,12 @@ module WireClient
       end
     )
   end
+
+  def self.today
+    if Time.zone.present?
+      Time.zone.now.to_date
+    else
+      Date.today
+    end
+  end
 end

--- a/lib/wire_client/transaction/credit_transfer_transaction.rb
+++ b/lib/wire_client/transaction/credit_transfer_transaction.rb
@@ -8,7 +8,7 @@ module WireClient
     validates_inclusion_of :service_level, :in => SERVICE_LEVEL_TYPES
 
     validate do |t|
-      t.validate_requested_date_after(Time.zone.now.to_date.next)
+      t.validate_requested_date_after(WireClient.today.next)
     end
 
     def initialize(attributes = {})

--- a/lib/wire_client/transaction/direct_debit_transaction.rb
+++ b/lib/wire_client/transaction/direct_debit_transaction.rb
@@ -23,7 +23,7 @@ module WireClient
     validates_inclusion_of :service_level, :in => SERVICE_LEVEL_TYPES
 
     validate do |t|
-      t.validate_requested_date_after(Time.zone.now.to_date.next)
+      t.validate_requested_date_after(WireClient.today.next)
     end
 
     validate do |t|
@@ -32,7 +32,7 @@ module WireClient
       end
 
       if t.mandate_date_of_signature.is_a?(Date)
-        if t.mandate_date_of_signature > Time.zone.now.to_date
+        if t.mandate_date_of_signature > WireClient.today
           errors.add(:mandate_date_of_signature, 'is in the future')
         end
       else

--- a/lib/wire_client/transaction/transaction.rb
+++ b/lib/wire_client/transaction/transaction.rb
@@ -3,8 +3,6 @@ module WireClient
     include ActiveModel::Validations
     extend Converter
 
-    DEFAULT_REQUESTED_DATE = Time.zone.now.to_date.freeze
-
     attr_accessor :name,
                   :iban,
                   :bic,
@@ -53,7 +51,7 @@ module WireClient
       @country ||= 'US'
       @clear_system_code ||= 'USABA'
       @agent_name ||= 'NOTPROVIDED'
-      @requested_date ||= DEFAULT_REQUESTED_DATE
+      @requested_date ||= default_requested_date
       @reference ||= 'NOTPROVIDED'
       @batch_booking = true if @batch_booking.nil?
       @service_priority ||= 'NORM'
@@ -72,10 +70,14 @@ module WireClient
 
     protected
 
+    def default_requested_date
+      WireClient.today.freeze
+    end
+
     def validate_requested_date_after(min_requested_date)
       return unless requested_date.is_a?(Date)
 
-      if requested_date != DEFAULT_REQUESTED_DATE &&
+      if requested_date != default_requested_date &&
          requested_date < min_requested_date
         errors.add(
           :requested_date,

--- a/test/lib/wire_client_test.rb
+++ b/test/lib/wire_client_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+describe WireClient do
+  describe :today do
+    it 'should return a Date instance if Time.zone is present' do
+      original_zone = Time.zone
+      Time.zone = 'Eastern Time (US & Canada)'
+      assert_equal WireClient.today, Date.new(2016, 8, 11)
+      Time.zone = original_zone
+    end
+
+    it 'should return a Date instance even if Time.zone is not present' do
+      original_zone = Time.zone
+      Time.zone = nil
+      assert_equal WireClient.today, Date.new(2016, 8, 11)
+      Time.zone = original_zone
+    end
+  end
+end


### PR DESCRIPTION
It shouldn't be a premise to set a `Time.zone` instance/value