### PR TITLE
Add StrtNm field to address sections

### DIFF
--- a/lib/wire_client/messages/message.rb
+++ b/lib/wire_client/messages/message.rb
@@ -152,6 +152,7 @@ module WireClient
     end
 
     def entity_address(builder, entity)
+      builder.StrtNm(entity.address_line)
       builder.PstCd(entity.postal_code)
       builder.TwnNm(entity.city)
       builder.CtrySubDvsn(entity.country_subdivision_abbr)

--- a/lib/wire_client/version.rb
+++ b/lib/wire_client/version.rb
@@ -1,4 +1,4 @@
 module WireClient
   # Increment this when changes are published
-  VERSION = '0.1.4'
+  VERSION = '0.2.0'
 end

--- a/test/lib/wire_client/providers/sftp/wire_credit_batch_test.rb
+++ b/test/lib/wire_client/providers/sftp/wire_credit_batch_test.rb
@@ -44,6 +44,7 @@ class SftpProvider
         assert_includes file_body, "<Nm>#{WireClient::HSBC::WireBatch.initiator_name}</Nm>"
         assert_includes file_body, "<PstCd>02115</PstCd>"
         assert_includes file_body, "<AdrLine>1 Nowhere Line</AdrLine>"
+        assert_includes file_body, "<StrtNm>1 Nowhere Line</StrtNm>"
         assert_includes file_body, "<TwnNm>Boston</TwnNm>"
         assert_includes file_body, "<CtrySubDvsn>MA</CtrySubDvsn>"
         assert_includes file_body, "<Ctry>US</Ctry>"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,7 +15,7 @@ require 'minitest/reporters'
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 Minitest::Reporters.use!
 
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'pry'
 
 # Freeze time so we don't have to worry about Time.now relativity


### PR DESCRIPTION
Some banks require the StrtNm field instead of AdrLine, so we provide both