### PR TITLE
need to allow higher version of sucker punch

### DIFF
--- a/lib/wire_client/version.rb
+++ b/lib/wire_client/version.rb
@@ -1,4 +1,4 @@
 module WireClient
   # Increment this when changes are published
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/wire_client.gemspec
+++ b/wire_client.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'net-sftp'
 
   # Asynchronocity w/out extra infrastucture dependency (database/redis)
-  spec.add_dependency 'sucker_punch', '~> 2'
+  spec.add_dependency 'sucker_punch', '>= 2'
 
   #spec.add_development_dependency 'bundler', '~> 2.1.4'
   spec.add_development_dependency 'codeclimate-test-reporter'


### PR DESCRIPTION
need this to be able to resolve a version of sucker punch.
https://github.com/ForwardFinancing/ach_client/blob/main/ach_client.gemspec#L46