### PR TITLE
ci: Start a CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: ruby:3.1.3
+    steps:
+      - checkout
+      - run:
+          name: Run the default task
+          command: |
+            gem install bundler -v 2.4.10
+            bundle install
+            bundle exec rake

--- a/test/lib/wire_client/providers/abstract/wire_batch_test.rb
+++ b/test/lib/wire_client/providers/abstract/wire_batch_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class AbstractProvider
-  class AbstractWireBatchTest < MiniTest::Test
+  class AbstractWireBatchTest < Minitest::Test
     def test_abstractfulness
       assert_raises(AbstractMethodError) do
         WireClient::Abstract::WireBatch.new(

--- a/test/lib/wire_client/providers/sftp/wire_credit_batch_test.rb
+++ b/test/lib/wire_client/providers/sftp/wire_credit_batch_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class SftpProvider
-  class WireCreditBatchTest < MiniTest::Test
+  class WireCreditBatchTest < Minitest::Test
     def conn_info
       lambda do |host, username, options|
         assert_equal WireClient::HSBC.host, host

--- a/test/lib/wire_client/providers/sftp/wire_debit_batch_test.rb
+++ b/test/lib/wire_client/providers/sftp/wire_debit_batch_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class SftpProvider
-  class WireDebitBatchTest < MiniTest::Test
+  class WireDebitBatchTest < Minitest::Test
     def eur_debit_batch
       sample = WireClient::HSHNordbankHamburg::WireBatch.new(
         transaction_type: WireClient::TransactionTypes::Debit

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,7 +27,7 @@ require 'sucker_punch/testing/inline'
 
 require 'wire_client'
 
-module MiniTest::Assertions
+module Minitest::Assertions
   def assert_valid_values(klass, values:, attributes:)
     attributes.each do |attribute|
       values.each do |value|


### PR DESCRIPTION
Adds CircleCI config running `bundle exec rake` on ruby:3.1.3.

Follow-up commit fixes pre-existing test files that referenced the deprecated `MiniTest` (capital T) constant — the alias was removed in modern minitest 5.x and was blocking the first CI run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds CI configuration and updates test class/module constants; no production logic changes.
> 
> **Overview**
> Adds a basic CircleCI pipeline (`.circleci/config.yml`) that runs `bundle install` and `bundle exec rake` on Ruby `3.1.3`.
> 
> Updates the test suite to consistently use `Minitest` (`Minitest::Test` and `Minitest::Assertions`) instead of the older `MiniTest` constant naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fe6687d54e9509d9d9c2037f38decbbdf54c574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->